### PR TITLE
adds hint to package needed to be able to run divio addon validate

### DIFF
--- a/how-to/create-addon.rst
+++ b/how-to/create-addon.rst
@@ -213,9 +213,9 @@ You can test that the project now works as expected.
 Validate it
 ^^^^^^^^^^^
 
-You will need the python package "aldryn-client" installed to be able to validate your addon.
+You will need the python package ``aldryn-client`` installed to be able to validate your addon.
 
-Run::
+If you have not already installed it, run::
 
     pip install aldryn-client
 

--- a/how-to/create-addon.rst
+++ b/how-to/create-addon.rst
@@ -213,6 +213,12 @@ You can test that the project now works as expected.
 Validate it
 ^^^^^^^^^^^
 
+You will need the python package "aldryn-client" installed to be able to validate your addon.
+
+Run::
+
+    pip install aldryn-client
+
 Now make sure you're in the ``addons-dev/<package name>`` directory.
 
 Now, running ``divio addon validate`` should now confirm that the addon is


### PR DESCRIPTION
Otherwise you get following error:

```
An error occurred during validating 'aldryn_config.py'. Please check the exception below:

Error: Traceback (most recent call last):
  File "/home/vladox/.local/lib/python2.7/site-packages/divio_cli/validators/addon.py", line 30, in validate_aldryn_config_py
    module = imp.load_source(source, temp_path)
  File "/tmp/tmp_divio_cli_nbFs5G/aldryn_config.py", line 2, in <module>
    from aldryn_client import forms
ImportError: No module named aldryn_client
```