### PR TITLE
Updated links and fixed typos

### DIFF
--- a/how-to/interact-database.rst
+++ b/how-to/interact-database.rst
@@ -262,7 +262,7 @@ Create a database named ``db``:
 Apply the ``hstore`` extension
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Apply the ``hstore`` extension (required on a newly-created local database) to he database named
+Apply the ``hstore`` extension (required on a newly-created local database) to the database named
 ``db``:
 
 ..  code-block:: bash

--- a/introduction/02-set-up.rst
+++ b/introduction/02-set-up.rst
@@ -58,7 +58,7 @@ with the ``divio project setup`` command, for example::
 ..  note::
 
     You can find the exact command, and other useful commands, in
-    `this cheat sheet
+    `our local commands cheat sheet
     <https://docs.divio.com/en/latest/reference/local-commands-cheatsheet.html>`_.
 
 Various processes will unfold, taking a few minutes (see :ref:`build-process`

--- a/introduction/02-set-up.rst
+++ b/introduction/02-set-up.rst
@@ -57,8 +57,9 @@ with the ``divio project setup`` command, for example::
 
 ..  note::
 
-    You can find the exact command, and other useful commands, by selecting
-    *Local Development* from the project's menu in the Control Panel.
+    You can find the exact command, and other useful commands, in
+    `this cheat sheet
+    <https://docs.divio.com/en/latest/reference/local-commands-cheatsheet.html>`_.
 
 Various processes will unfold, taking a few minutes (see :ref:`build-process`
 for a description of them).

--- a/introduction/03-add-applications.rst
+++ b/introduction/03-add-applications.rst
@@ -8,7 +8,7 @@ Add new applications to the project
     At the time of writing, version 1.11 is `Django's Long-Term Support release
     <https://www.djangoproject.com/download/#supported-versions>`_, and is
     guaranteed support until at least April 2020.
-    
+
     If you use a different version, you will need to modify some of the code
     examples and version numbers of packages mentioned.
 
@@ -167,7 +167,7 @@ Add a package via pip
 ---------------------
 
 Often, you want to add a reusable, pip-installable application. For this
-example, we'll use `Django Axes <https://github.com/aldryn/aldryn-sso>`_,
+example, we'll use `Django Axes <https://github.com/jazzband/django-axes>`_,
 a simple package that keeps access logs (and failed login attempts) for a site.
 
 Add the package


### PR DESCRIPTION
This PR fixes three things:

1. Correct link to the `django-axes` project in https://docs.divio.com/en/latest/introduction/03-add-applications.html#add-a-package-via-pip
1. Fix typo in the [how to interact with database article](https://docs.divio.com/en/latest/how-to/interact-database.html)
1. https://docs.divio.com/en/latest/introduction/02-set-up.html refers to a "Local Development" section in the control panel. This section doesn't exist. I added link to [cheat sheet](https://docs.divio.com/en/latest/reference/local-commands-cheatsheet.html) instead.