### PR TITLE
Update django-manage-authentication.rst

### DIFF
--- a/how-to/django-manage-authentication.rst
+++ b/how-to/django-manage-authentication.rst
@@ -12,8 +12,8 @@ Require login
 -------------------
 
 By default, the Test site is password protected while the Live site is not. This is controlled by the
-:ref:`ALDRYN_SSO_ALWAYS_REQUIRE_LOGIN <ALDRYN_SSO_ALWAYS_REQUIRE_LOGIN>` environment variable (``False`` for Test,
-``True`` for Live).
+:ref:`ALDRYN_SSO_ALWAYS_REQUIRE_LOGIN <ALDRYN_SSO_ALWAYS_REQUIRE_LOGIN>` environment variable (``True`` for Test,
+``False`` for Live).
 
 To override the behaviour, you can set the value explicitly in the *Environment variables* view in the Control Panel.
 


### PR DESCRIPTION
Defaults for TEST and LIVE environment for ALDRYN_SSO_ALWAYS_REQUIRE_LOGIN are swapped